### PR TITLE
allow to push into remote, even if brach does not exist

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,4 +48,5 @@ git status
 git diff-index --quiet HEAD || git commit --message "$COMMIT_MESSAGE"
 
 echo "Pushing git commit"
-git push origin -u "$TARGET_BRANCH"
+# --set-upstream: sets de branch when pushing to a remote empty repository
+git push origin --set-upstream "$TARGET_BRANCH"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,4 +48,4 @@ git status
 git diff-index --quiet HEAD || git commit --message "$COMMIT_MESSAGE"
 
 echo "Pushing git commit"
-git push origin "$TARGET_BRANCH"
+git push origin -u "$TARGET_BRANCH"


### PR DESCRIPTION
Use case: I'm trying to push to a new empty remote repository -https://github.com/symplify/markdown-diff

But GitHub Actoin fails https://github.com/symplify/symplify/runs/1377386089

<br>

To be able to push to a brand empty repository, the `-u` option is needed, see 
https://stackoverflow.com/questions/6074009/doing-git-push-without-origin-master

<br>

Is pull-request good enough or you want me to change something? 