### PR TITLE
Support force pushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ The directory to wipe and replace in the target repository.  Defaults to wiping 
 
 The string `ORIGIN_COMMIT` is replaced by `$REPOSITORY_URL@commit`.
 
+### `force` (argument) [optional]
+If "true", will force push to the target repo. Use with caution
+
+
 ### `API_TOKEN_GITHUB` (environment)
 E.g.:
   `API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}`

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,11 @@ inputs:
     description: '[Optional] The directory to wipe and replace in the target repository'
     default: ''
     required: false
-        
+  force:
+    description: "[Optional] If 'true', will force push and thus overwrite the target repo's history"
+    default: 'false'
+    required: false
+
 runs:
   using: docker
   image: Dockerfile
@@ -64,6 +68,7 @@ runs:
     - '${{ inputs.target-branch }}'
     - '${{ inputs.commit-message }}'
     - '${{ inputs.target-directory }}'
+    - '${{ inputs.force }}'
 branding:
   icon: git-commit
   color: green

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,7 @@ DESTINATION_REPOSITORY_USERNAME="$8"
 TARGET_BRANCH="$9"
 COMMIT_MESSAGE="${10}"
 TARGET_DIRECTORY="${11}"
+FORCE="${12}"
 
 if [ -z "$DESTINATION_REPOSITORY_USERNAME" ]
 then
@@ -102,6 +103,14 @@ echo "[+] git diff-index:"
 # git diff-index : to avoid doing the git commit failing if there are no changes to be commit
 git diff-index --quiet HEAD || git commit --message "$COMMIT_MESSAGE"
 
-echo "[+] Pushing git commit"
+if $FORCE; then
+  echo "[+] Force pushing git commit"
+  FORCE_FLAG="-f"
+else
+  echo "[+] Pushing git commit"
+  FORCE_FLAG=""
+fi
 # --set-upstream: sets de branch when pushing to a branch that does not exist
-git push "https://$USER_NAME:$API_TOKEN_GITHUB@$GITHUB_SERVER/$DESTINATION_REPOSITORY_USERNAME/$DESTINATION_REPOSITORY_NAME.git" --set-upstream "$TARGET_BRANCH"
+git push "https://$USER_NAME:$API_TOKEN_GITHUB@$GITHUB_SERVER/$DESTINATION_REPOSITORY_USERNAME/$DESTINATION_REPOSITORY_NAME.git" \
+ --set-upstream "$TARGET_BRANCH" \
+ "$FORCE_FLAG"


### PR DESCRIPTION
I needed to support force pushing as I use this action for demonstrating a cookiecutter template which creates an initial commit. Thus, pushing to an existing repo would always cause conflicting history. Force pushing in general should be a useful option for automatic commits :).

Example (my use case): https://github.com/appliedAI-Initiative/pymetrius pushing to https://github.com/appliedAI-Initiative/pymetrius_output