### PR TITLE
Fix the placement of a sentence in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ The branch name for the destination repository. It defaults to `main`.
 ### `commit-message` (argument) [optional]
 The commit message to be used in the output repository. Optional and defaults to "Update from $REPOSITORY_URL@commit".
 
+The string `ORIGIN_COMMIT` is replaced by `$REPOSITORY_URL@commit`.
+
 ### `target-directory` (argument) [optional]
 The directory to wipe and replace in the target repository.  Defaults to wiping the entire repository
-
-The string `ORIGIN_COMMIT` is replaced by `$REPOSITORY_URL@commit`.
 
 ### `API_TOKEN_GITHUB` (environment)
 E.g.:


### PR DESCRIPTION
When `target-directory` was added, it was put in between the two sentences related to `commit-message`.  This moves the second sentence back where it belongs.