### PR TITLE
Feature: Preserving arbitrary missing files from deletion

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,10 @@ inputs:
     description: '[Optional] The directory to wipe and replace in the target repository'
     default: ''
     required: false
-        
+  do-not-delete-list-file:
+    description: '[Optional] File path to a txt file containing each relative path that should be copied from the cloned dir, meaning its not wiped'
+    required: false
+    default: ''
 runs:
   using: docker
   image: Dockerfile
@@ -64,6 +67,7 @@ runs:
     - '${{ inputs.target-branch }}'
     - '${{ inputs.commit-message }}'
     - '${{ inputs.target-directory }}'
+    - '${{ inputs.do-not-delete-list-file }}'
 branding:
   icon: git-commit
   color: green


### PR DESCRIPTION
Heya,

Thanks for the work you've done it was very useful for something we needed internally at my agency.

We needed additional functionality of:
Say you have repo A, copying to repo B. But there were some files within Repo B that were not in A it was required they were not deleted.

To get around this I've added a new property :
> do-not-delete-list-file: '.github/pipeline-copy-preserve.conf'

The format of which is just newline delimited list of paths to preserve.
In my case it has the following defined:
> azure-pipelines.yml
bitbucket-pipelines.yml
README.md
.github
Dockerfile
docker-compose.yml
.dockerignore


I achieved this by within the entrypoint.sh copying files from the cloned directory into the TEMP_DIR (the same area you were preserving the .git folder). and then re-iterating through the list when copying them back to the folder prior to committing & pushing.

No worries if this is a feature you don't want (or if you spot mistakes, I'm not in a habit of writing .sh scripts).