### PR TITLE
Add support for creation of non-existent target branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: '[Optional] The directory to wipe and replace in the target repository'
     default: ''
     required: false
+  create-target-branch:
+    description: '[Optional] Boolean indicating whether to create target branch if it does not exist'
+    default: 'false'
+    required: false
         
 runs:
   using: docker
@@ -64,6 +68,7 @@ runs:
     - '${{ inputs.target-branch }}'
     - '${{ inputs.commit-message }}'
     - '${{ inputs.target-directory }}'
+    - '${{ inputs.create-target-branch }}'
 branding:
   icon: git-commit
   color: green

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,6 +65,7 @@ echo "[+] Cloning destination git repository $DESTINATION_REPOSITORY_NAME"
 # Setup git
 git config --global user.email "$USER_EMAIL"
 git config --global user.name "$USER_NAME"
+git config --global --add safe.directory /github/workspace
 
 if ! git clone --single-branch --depth 1 --branch "$TARGET_BRANCH" "$GIT_CMD_REPOSITORY" "$CLONE_DIR"; then
 	if ${CREATE_TARGET_BRANCH} && git clone --single-branch --depth 1 "$GIT_CMD_REPOSITORY" "$CLONE_DIR"; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,8 +72,14 @@ if ! git clone --single-branch --depth 1 --branch "$TARGET_BRANCH" "$GIT_CMD_REP
 	if ${CREATE_TARGET_BRANCH} && git clone --single-branch --depth 1 "$GIT_CMD_REPOSITORY" "$CLONE_DIR"; then
 		new_target_branch=1
 	else
-		echo "::error::Could not clone the destination repository."
-		echo "::error::Please verify that the target repository exists and is accesible with your API_TOKEN_GITHUB OR SSH_DEPLOY_KEY"
+		echo "::error::Could not clone the destination repository ('$GIT_CMD_REPOSITORY')."
+		echo -n "::error::Please verify that the target repository exists and is accesible with your API_TOKEN_GITHUB OR SSH_DEPLOY_KEY"
+		if ${CREATE_TARGET_BRANCH}; then
+			echo "."
+		else
+			echo ""
+			echo "::error::and that it contains the target branch ('$TARGET_BRANCH')."
+		fi
 		exit 1
 	fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,9 +69,7 @@ git config --global --add safe.directory /github/workspace
 
 if ! git clone --single-branch --depth 1 --branch "$TARGET_BRANCH" "$GIT_CMD_REPOSITORY" "$CLONE_DIR"; then
 	if ${CREATE_TARGET_BRANCH} && git clone --single-branch --depth 1 "$GIT_CMD_REPOSITORY" "$CLONE_DIR"; then
-		echo "[+] Creating branch ${TARGET_BRANCH}"
-		git branch ${TARGET_BRANCH}
-		git switch ${TARGET_BRANCH}
+		echo "[+] Creating target branch ${TARGET_BRANCH}"
 	else
 		echo "::error::Could not clone the destination repository. Command:"
 		echo "::error::git clone --single-branch --branch $TARGET_BRANCH $GIT_CMD_REPOSITORY $CLONE_DIR"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,6 +57,7 @@ fi
 
 
 CLONE_DIR=$(mktemp -d)
+new_target_branch=0
 
 echo "[+] Git version"
 git --version
@@ -69,7 +70,7 @@ git config --global --add safe.directory /github/workspace
 
 if ! git clone --single-branch --depth 1 --branch "$TARGET_BRANCH" "$GIT_CMD_REPOSITORY" "$CLONE_DIR"; then
 	if ${CREATE_TARGET_BRANCH} && git clone --single-branch --depth 1 "$GIT_CMD_REPOSITORY" "$CLONE_DIR"; then
-		echo "[+] Creating target branch ${TARGET_BRANCH}"
+		new_target_branch=1
 	else
 		echo "::error::Could not clone the destination repository. Command:"
 		echo "::error::git clone --single-branch --branch $TARGET_BRANCH $GIT_CMD_REPOSITORY $CLONE_DIR"
@@ -137,6 +138,12 @@ echo "[+] Set directory is safe ($CLONE_DIR)"
 # Related to https://github.com/cpina/github-action-push-to-another-repository/issues/64 and https://github.com/cpina/github-action-push-to-another-repository/issues/64
 # TODO: review before releasing it as a version
 git config --global --add safe.directory "$CLONE_DIR"
+
+if [ ${new_target_branch} -ne 0 ]; then
+	echo "[+] Creating target branch ${TARGET_BRANCH}"
+	git branch ${TARGET_BRANCH}
+	git switch b1
+fi
 
 echo "[+] Adding git commit"
 git add .

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -142,7 +142,7 @@ git config --global --add safe.directory "$CLONE_DIR"
 if [ ${new_target_branch} -ne 0 ]; then
 	echo "[+] Creating target branch ${TARGET_BRANCH}"
 	git branch ${TARGET_BRANCH}
-	git switch b1
+	git switch ${TARGET_BRANCH}
 fi
 
 echo "[+] Adding git commit"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,10 +72,8 @@ if ! git clone --single-branch --depth 1 --branch "$TARGET_BRANCH" "$GIT_CMD_REP
 	if ${CREATE_TARGET_BRANCH} && git clone --single-branch --depth 1 "$GIT_CMD_REPOSITORY" "$CLONE_DIR"; then
 		new_target_branch=1
 	else
-		echo "::error::Could not clone the destination repository. Command:"
-		echo "::error::git clone --single-branch --branch $TARGET_BRANCH $GIT_CMD_REPOSITORY $CLONE_DIR"
-		echo "::error::(Note that if they exist USER_NAME and API_TOKEN is redacted by GitHub)"
-		echo "::error::Please verify that the target repository exist AND that it contains the destination branch name, and is accesible by the API_TOKEN_GITHUB OR SSH_DEPLOY_KEY"
+		echo "::error::Could not clone the destination repository."
+		echo "::error::Please verify that the target repository exists and is accesible with your API_TOKEN_GITHUB OR SSH_DEPLOY_KEY"
 		exit 1
 	fi
 fi


### PR DESCRIPTION
My use case for this action requires creation of target branch, if it does not exist. I assume that others may benefit from this functionality too.

I've added new optional input argument `create-target-branch` (defaulting to `false`). Default behavior of the action has not changed.