### PR TITLE
Feature: Create branch if needed option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,13 @@ inputs:
     description: '[Optional] The directory to wipe and replace in the target repository'
     default: ''
     required: false
-        
+  create-target-branch-if-needed:
+    type: boolean
+    description: >-
+      [Optional] create target branch if not exist. Defaults to `false`
+    default: false
+    required: false
+
 runs:
   using: docker
   image: Dockerfile
@@ -64,6 +70,7 @@ runs:
     - '${{ inputs.target-branch }}'
     - '${{ inputs.commit-message }}'
     - '${{ inputs.target-directory }}'
+    - '${{ inputs.create-target-branch-if-needed }}'
 branding:
   icon: git-commit
   color: green

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,7 @@ DESTINATION_REPOSITORY_USERNAME="${8}"
 TARGET_BRANCH="${9}"
 COMMIT_MESSAGE="${10}"
 TARGET_DIRECTORY="${11}"
+CREATE_TARGET_BRANCH_IF_NEEDED="${12}"
 
 if [ -z "$DESTINATION_REPOSITORY_USERNAME" ]
 then
@@ -70,6 +71,12 @@ git config --global user.name "$USER_NAME"
 
 {
 	git clone --single-branch --depth 1 --branch "$TARGET_BRANCH" "$GIT_CMD_REPOSITORY" "$CLONE_DIR"
+} || {
+  if [ "$CREATE_TARGET_BRANCH_IF_NEEDED" = 'true' ] ; then
+    git clone --single-branch --depth 1 "$GIT_CMD_REPOSITORY" "$CLONE_DIR"
+  else
+    false
+  fi
 } || {
 	echo "::error::Could not clone the destination repository. Command:"
 	echo "::error::git clone --single-branch --branch $TARGET_BRANCH $GIT_CMD_REPOSITORY $CLONE_DIR"
@@ -136,6 +143,11 @@ echo "[+] Set directory is safe ($CLONE_DIR)"
 # Related to https://github.com/cpina/github-action-push-to-another-repository/issues/64 and https://github.com/cpina/github-action-push-to-another-repository/issues/64
 # TODO: review before releasing it as a version
 git config --global --add safe.directory "$CLONE_DIR"
+
+
+if [ "$CREATE_TARGET_BRANCH_IF_NEEDED" = 'true' ] ; then
+  git checkout -b "$TARGET_BRANCH"
+fi
 
 echo "[+] Adding git commit"
 git add .


### PR DESCRIPTION
Hello,

Thank you for the initial work on this GitHub action!

We are in a use case where the target branch will not exist most of the time. Meaning at the moment of the clone we know the branch does not exist but for the use case it's expected.
Adding a boolean option to let the action work nonetheless `create-target-branch-if-needed`.

Strategy is to clone only the repo's default branch instead of the target branch and then create our branch from it before adding our files and committing.

As of now I'm not super happy with the error that will be displayed in the actions' annotations as it's using the same message as in the current clone command (that includes the target branch that might not be existing which leads to confusion).