### PR TITLE
Add exclude directories option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,7 @@ inputs:
     required: false
   exclude-directories:
     description: '[Optional] The directory to exclude for remove from remote repo'
+    default: ''
     required: false
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,9 @@ inputs:
       [Optional] create target branch if not exist. Defaults to `false`
     default: false
     required: false
+  exclude-directories:
+    description: '[Optional] The directory to exclude for remove from remote repo'
+    required: false
 
 runs:
   using: docker
@@ -71,6 +74,7 @@ runs:
     - '${{ inputs.commit-message }}'
     - '${{ inputs.target-directory }}'
     - '${{ inputs.create-target-branch-if-needed }}'
+    - '${{ inputs.exclude-directories }}'
 branding:
   icon: git-commit
   color: green

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -160,8 +160,8 @@ git add .
 if [ -n "$EXCLUDE_DIRECTORIES" ]
 then
 	echo "[+] Checkout excluded dirs"
-	git reset -- "$EXCLUDE_DIRECTORIES"
-	git restore "$EXCLUDE_DIRECTORIES"
+	git reset -- $(echo $EXCLUDE_DIRECTORIES)
+	git restore $(echo $EXCLUDE_DIRECTORIES)
 fi
 echo "[+] git status:"
 git status

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,7 @@ TARGET_BRANCH="${9}"
 COMMIT_MESSAGE="${10}"
 TARGET_DIRECTORY="${11}"
 CREATE_TARGET_BRANCH_IF_NEEDED="${12}"
+EXCLUDE_DIRECTORIES="${13}"
 
 if [ -z "$DESTINATION_REPOSITORY_USERNAME" ]
 then
@@ -115,7 +116,7 @@ mv "$TEMP_DIR/.git" "$CLONE_DIR/.git"
 
 echo "[+] List contents of $SOURCE_DIRECTORY"
 ls "$SOURCE_DIRECTORY"
-
+rm -rf "$SOURCE_DIRECTORY/.git"
 echo "[+] Checking if local $SOURCE_DIRECTORY exist"
 if [ ! -d "$SOURCE_DIRECTORY" ]
 then
@@ -136,6 +137,7 @@ cp -ra "$SOURCE_DIRECTORY"/. "$CLONE_DIR/$TARGET_DIRECTORY"
 cd "$CLONE_DIR"
 
 echo "[+] Files that will be pushed"
+chown -R $(id -u):$(id -g) .
 ls -la
 
 ORIGIN_COMMIT="https://$GITHUB_SERVER/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"
@@ -155,7 +157,12 @@ fi
 
 echo "[+] Adding git commit"
 git add .
-
+if [ -n "$EXCLUDE_DIRECTORIES" ]
+then
+	echo "[+] Checkout excluded dirs"
+	git reset -- "$EXCLUDE_DIRECTORIES"
+	git restore "$EXCLUDE_DIRECTORIES"
+fi
 echo "[+] git status:"
 git status
 


### PR DESCRIPTION
Hello. I want to thank you for this useful action. I'm trying to use it to create website github pages for our [project](https://github.com/openglobus/openglobus). 

 While working on it, I encountered that when I try to update the repository root, some directories that I also created with this action get overwritten (similar to the problem in [this issue](#97)).

So I added the ability to select which directories to exclude from the rewriting process with the `exclude-directories` parameter.I do this with the `git restore` command

I also added removing `.git` directories from nested directories, because if you don't, they will look like git submodules. You may have done this in some special way, and I should do it some other way.

I hope these changes will be helpful 