### PR TITLE
Option to keep gitattributes from target branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,12 @@ inputs:
       [Optional] create target branch if not exist. Defaults to `false`
     default: false
     required: false
+  keep-gitattributes:
+    type: boolean
+    description: >-
+      [Optional] If true, .gitattributes will not be overwritten. Required for LFS in target repo. Defaults to `false`
+    default: false
+    required: false
 
 runs:
   using: docker
@@ -71,6 +77,7 @@ runs:
     - '${{ inputs.commit-message }}'
     - '${{ inputs.target-directory }}'
     - '${{ inputs.create-target-branch-if-needed }}'
+    - '${{ inputs.keep-gitattributes }}'
 branding:
   icon: git-commit
   color: green

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,7 @@ TARGET_BRANCH="${9}"
 COMMIT_MESSAGE="${10}"
 TARGET_DIRECTORY="${11}"
 CREATE_TARGET_BRANCH_IF_NEEDED="${12}"
+KEEP_GITATTRIBUTES="${13}"
 
 if [ -z "$DESTINATION_REPOSITORY_USERNAME" ]
 then
@@ -100,6 +101,13 @@ TEMP_DIR=$(mktemp -d)
 # including "." and with the exception of ".git/"
 mv "$CLONE_DIR/.git" "$TEMP_DIR/.git"
 
+# If enabled, copy .gitattributes file to keep LFS working.
+if [ "$KEEP_GITATTRIBUTES" = "true" ]
+then
+	mv "$CLONE_DIR/.gitattributes" "$TEMP_DIR/.gitattributes"
+fi
+
+
 # $TARGET_DIRECTORY is '' by default
 ABSOLUTE_TARGET_DIRECTORY="$CLONE_DIR/$TARGET_DIRECTORY/"
 
@@ -116,6 +124,11 @@ echo "[+] Listing root Location"
 ls -al /
 
 mv "$TEMP_DIR/.git" "$CLONE_DIR/.git"
+# If enabled, restore .gitattributes file to keep LFS working.
+if [ "$KEEP_GITATTRIBUTES" = "true" ]
+then
+	mv "$TEMP_DIR/.gitattributes" "$CLONE_DIR/.gitattributes"
+fi
 
 echo "[+] List contents of $SOURCE_DIRECTORY"
 ls "$SOURCE_DIRECTORY"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -100,12 +100,7 @@ TEMP_DIR=$(mktemp -d)
 # but not anymore. Otherwise we had to remove the files from "$CLONE_DIR",
 # including "." and with the exception of ".git/"
 mv "$CLONE_DIR/.git" "$TEMP_DIR/.git"
-
-# If enabled, copy .gitattributes file to keep LFS working.
-if [ "$KEEP_GITATTRIBUTES" = "true" ]
-then
-	mv "$CLONE_DIR/.gitattributes" "$TEMP_DIR/.gitattributes"
-fi
+mv "$CLONE_DIR/.gitattributes" "$TEMP_DIR/.gitattributes"
 
 
 # $TARGET_DIRECTORY is '' by default
@@ -127,6 +122,7 @@ mv "$TEMP_DIR/.git" "$CLONE_DIR/.git"
 # If enabled, restore .gitattributes file to keep LFS working.
 if [ "$KEEP_GITATTRIBUTES" = "true" ]
 then
+	echo "[+] Restoring .gitattributes file"
 	mv "$TEMP_DIR/.gitattributes" "$CLONE_DIR/.gitattributes"
 fi
 


### PR DESCRIPTION
This adds an option to keep .gitattributes file from the target branch or from the default branch, if target branch does not exist. Without this, push fails on LFS upload of files bigger than 50Mb.
