### PR TITLE
Add support for single file transfer without clearing target directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,14 @@ inputs:
       [Optional] create target branch if not exist. Defaults to `false`
     default: false
     required: false
+  source-file:
+    description: '[Optional] Source file to transfer'
+    required: false
+    default: ''
+  target-file:
+    description: '[Optional] Target file path in destination repository'
+    required: false
+    default: ''
 
 runs:
   using: docker
@@ -71,6 +79,8 @@ runs:
     - '${{ inputs.commit-message }}'
     - '${{ inputs.target-directory }}'
     - '${{ inputs.create-target-branch-if-needed }}'
+    - '${{ inputs.source-file }}'
+    - '${{ inputs.target-file }}'
 branding:
   icon: git-commit
   color: green

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,7 +102,7 @@ TEMP_DIR=$(mktemp -d)
 # including "." and with the exception of ".git/"
 mv "$CLONE_DIR/.git" "$TEMP_DIR/.git"
 
-# check if sourcefile and target file is not set
+# Do this if sourcefile and target file is not set, means we are doing a directory transfer
 if [ -z "$SOURCE_FILE" ] && [ -z "$TARGET_FILE" ]
 then
 	# $TARGET_DIRECTORY is '' by default
@@ -123,8 +123,8 @@ ls -al /
 
 mv "$TEMP_DIR/.git" "$CLONE_DIR/.git"
 
-# if source directory is set
-if [ -n "$SOURCE_DIRECTORY" ]
+# If sourcefile and target file is not set, means we are doing a directory transfer
+if [ -z "$SOURCE_FILE" ] && [ -z "$TARGET_FILE" ]
 then
     echo "[+] List contents of $SOURCE_DIRECTORY"
     ls "$SOURCE_DIRECTORY"
@@ -144,10 +144,11 @@ then
 		exit 1
 	fi
 
-echo "[+] Copying contents of source repository folder $SOURCE_DIRECTORY to folder $TARGET_DIRECTORY in git repo $DESTINATION_REPOSITORY_NAME"
-cp -ra "$SOURCE_DIRECTORY"/. "$CLONE_DIR/$TARGET_DIRECTORY"
+	echo "[+] Copying contents of source repository folder $SOURCE_DIRECTORY to folder $TARGET_DIRECTORY in git repo $DESTINATION_REPOSITORY_NAME"
+	cp -ra "$SOURCE_DIRECTORY"/. "$CLONE_DIR/$TARGET_DIRECTORY"
 fi
 
+# If sourcefile and target file is set, means we are doing a file transfer
 if [ -n "$SOURCE_FILE" ] && [ -n "$TARGET_FILE" ]
 then
 	echo "[+] SOURCE_FILE: $SOURCE_FILE"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -113,15 +113,15 @@ then
 
 	echo "[+] Creating (now empty) $ABSOLUTE_TARGET_DIRECTORY"
 	mkdir -p "$ABSOLUTE_TARGET_DIRECTORY"
-
-	echo "[+] Listing Current Directory Location"
-	ls -al
-
-	echo "[+] Listing root Location"
-	ls -al /
-
-	mv "$TEMP_DIR/.git" "$CLONE_DIR/.git"
 fi
+
+echo "[+] Listing Current Directory Location"
+ls -al
+
+echo "[+] Listing root Location"
+ls -al /
+
+mv "$TEMP_DIR/.git" "$CLONE_DIR/.git"
 
 # if source directory is set
 if [ -n "$SOURCE_DIRECTORY" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,22 +102,26 @@ TEMP_DIR=$(mktemp -d)
 # including "." and with the exception of ".git/"
 mv "$CLONE_DIR/.git" "$TEMP_DIR/.git"
 
-# $TARGET_DIRECTORY is '' by default
-ABSOLUTE_TARGET_DIRECTORY="$CLONE_DIR/$TARGET_DIRECTORY/"
+# check if sourcefile and target file is not set
+if [ -z "$SOURCE_FILE" ] && [ -z "$TARGET_FILE" ]
+then
+	# $TARGET_DIRECTORY is '' by default
+	ABSOLUTE_TARGET_DIRECTORY="$CLONE_DIR/$TARGET_DIRECTORY/"
 
-echo "[+] Deleting $ABSOLUTE_TARGET_DIRECTORY"
-rm -rf "$ABSOLUTE_TARGET_DIRECTORY"
+	echo "[+] Deleting $ABSOLUTE_TARGET_DIRECTORY"
+	rm -rf "$ABSOLUTE_TARGET_DIRECTORY"
 
-echo "[+] Creating (now empty) $ABSOLUTE_TARGET_DIRECTORY"
-mkdir -p "$ABSOLUTE_TARGET_DIRECTORY"
+	echo "[+] Creating (now empty) $ABSOLUTE_TARGET_DIRECTORY"
+	mkdir -p "$ABSOLUTE_TARGET_DIRECTORY"
 
-echo "[+] Listing Current Directory Location"
-ls -al
+	echo "[+] Listing Current Directory Location"
+	ls -al
 
-echo "[+] Listing root Location"
-ls -al /
+	echo "[+] Listing root Location"
+	ls -al /
 
-mv "$TEMP_DIR/.git" "$CLONE_DIR/.git"
+	mv "$TEMP_DIR/.git" "$CLONE_DIR/.git"
+fi
 
 # if source directory is set
 if [ -n "$SOURCE_DIRECTORY" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,8 @@ TARGET_BRANCH="${9}"
 COMMIT_MESSAGE="${10}"
 TARGET_DIRECTORY="${11}"
 CREATE_TARGET_BRANCH_IF_NEEDED="${12}"
+SOURCE_FILE="${13}"
+TARGET_FILE="${14}"
 
 if [ -z "$DESTINATION_REPOSITORY_USERNAME" ]
 then
@@ -117,26 +119,53 @@ ls -al /
 
 mv "$TEMP_DIR/.git" "$CLONE_DIR/.git"
 
-echo "[+] List contents of $SOURCE_DIRECTORY"
-ls "$SOURCE_DIRECTORY"
-
-echo "[+] Checking if local $SOURCE_DIRECTORY exist"
-if [ ! -d "$SOURCE_DIRECTORY" ]
+# if source directory is set
+if [ -n "$SOURCE_DIRECTORY" ]
 then
-	echo "ERROR: $SOURCE_DIRECTORY does not exist"
-	echo "This directory needs to exist when push-to-another-repository is executed"
-	echo
-	echo "In the example it is created by ./build.sh: https://github.com/cpina/push-to-another-repository-example/blob/main/.github/workflows/ci.yml#L19"
-	echo
-	echo "If you want to copy a directory that exist in the source repository"
-	echo "to the target repository: you need to clone the source repository"
-	echo "in a previous step in the same build section. For example using"
-	echo "actions/checkout@v2. See: https://github.com/cpina/push-to-another-repository-example/blob/main/.github/workflows/ci.yml#L16"
-	exit 1
-fi
+    echo "[+] List contents of $SOURCE_DIRECTORY"
+    ls "$SOURCE_DIRECTORY"
+
+    echo "[+] Checking if local $SOURCE_DIRECTORY exist"
+    if [ ! -d "$SOURCE_DIRECTORY" ]
+	then
+		echo "ERROR: $SOURCE_DIRECTORY does not exist"
+		echo "This directory needs to exist when push-to-another-repository is executed"
+		echo
+		echo "In the example it is created by ./build.sh: https://github.com/cpina/push-to-another-repository-example/blob/main/.github/workflows/ci.yml#L19"
+		echo
+		echo "If you want to copy a directory that exist in the source repository"
+		echo "to the target repository: you need to clone the source repository"
+		echo "in a previous step in the same build section. For example using"
+		echo "actions/checkout@v2. See: https://github.com/cpina/push-to-another-repository-example/blob/main/.github/workflows/ci.yml#L16"
+		exit 1
+	fi
 
 echo "[+] Copying contents of source repository folder $SOURCE_DIRECTORY to folder $TARGET_DIRECTORY in git repo $DESTINATION_REPOSITORY_NAME"
 cp -ra "$SOURCE_DIRECTORY"/. "$CLONE_DIR/$TARGET_DIRECTORY"
+fi
+
+if [ -n "$SOURCE_FILE" ] && [ -n "$TARGET_FILE" ]
+then
+	echo "[+] SOURCE_FILE: $SOURCE_FILE"
+	echo "[+] TARGET_FILE: $TARGET_FILE"
+
+    echo "[+] Copying single file from $SOURCE_FILE to $TARGET_FILE"
+    if [ ! -f "$SOURCE_FILE" ]
+    then
+        echo "::error::Source file $SOURCE_FILE does not exist"
+        exit 1
+    fi
+    
+    # Create target directory if it doesn't exist
+    TARGET_FILE_DIR=$(dirname "$CLONE_DIR/$TARGET_FILE")
+    mkdir -p "$TARGET_FILE_DIR"
+    
+    # Copy the file
+    cp "$SOURCE_FILE" "$CLONE_DIR/$TARGET_FILE"
+fi
+
+
+
 cd "$CLONE_DIR"
 
 echo "[+] Files that will be pushed"


### PR DESCRIPTION
Currently, when transferring content to another repository, the action clears the entire target directory before copying new content. This can be problematic when you want to preserve existing files in the destination directory and only update specific files.

### Changes Made
- Added new input parameters:
  - `source-file`: Path to the source file to transfer
  - `target-file`: Destination path in the target repository
- Modified the entrypoint script to support two modes:
  1. Directory transfer (existing behavior)
  2. Single file transfer (new feature)
- When using single file transfer:
  - Target directory is not cleared
  - Only the specified file is copied
  - Parent directories are created if they don't exist

### Example Usage
```yaml
  uses: cpina/github-action-push-to-another-repository@main
  with:
   source-file: 'path/to/source/file.txt'
   target-file: 'path/in/destination/file.txt'
   # ... other required parameters ...
```

### Benefits
- Allows selective file transfers without affecting other files
- Preserves existing content in destination repository
- More granular control over file transfers

### Testing Done
- Verified file transfer works without clearing target directory
- Confirmed creation of parent directories if needed
- Tested error handling for non-existent source files
