### PR TITLE
Fix OpenSSL version mismatch in Alpine container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:latest
+FROM alpine:3.20
 
-RUN apk add --no-cache git git-lfs openssh-client
+RUN apk update && apk add --no-cache git git-lfs openssh-client openssl
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,61 @@
-# github-action-push-to-another-repository
+# GitHub Action: Push to Another Repository (Fixed Fork)
 
-> [!WARNING]
-> TL;DR: this repository is not maintained for any new development. I plan to
-> fix issues if they arise due to changes on GitHub, to minimise disruption of
-> existing usage.
->
-> My circumstances changed since I started the GitHub Action in 2020. I am not
-> able to add functionality to it or fix issues.
->
-> The action is 175 lines of shell script. Feel free to fork it and modify it
-> for your own use case.
->
-> If you create a fork that might replace this one, I will add a note in the
-> documentation and the README.md. Please, open an issue and I will do it.
+## Why This Fork Exists
 
-See the extensive documentation in https://cpina.github.io/push-to-another-repository-docs/ (includes examples, FAQ, troubleshooting, etc.).
+This is a fork of [cpina/github-action-push-to-another-repository](https://github.com/cpina/github-action-push-to-another-repository) created to fix a critical OpenSSL version mismatch issue that was causing deployment failures.
 
-GitHub repository of the documentation: https://github.com/cpina/push-to-another-repository-docs
+## What Was Changed
+
+### OpenSSL Version Mismatch Fix
+
+**Problem**: The original action was failing with the error:
+```
+OpenSSL version mismatch. Built against 3050003f, you have 30500010
+```
+
+**Root Cause**: The Alpine Linux base image was using inconsistent OpenSSL versions between the container's SSH client and the system's OpenSSL library.
+
+**Solution**: Updated the Dockerfile to:
+1. Pin Alpine to version 3.20 for consistency
+2. Explicitly install the `openssl` package alongside other dependencies
+3. Update package index before installation
+
+### Changes Made
+
+**Before**:
+```dockerfile
+FROM alpine:latest
+RUN apk add --no-cache git git-lfs openssh-client
+```
+
+**After**:
+```dockerfile
+FROM alpine:3.20
+RUN apk update && apk add --no-cache git git-lfs openssh-client openssl
+```
+
+## Usage
+
+Use this fork in your GitHub Actions workflows:
+
+```yaml
+- name: Push to another repository
+  uses: Play-Perfect/github-action-push-to-another-repository@main
+  with:
+    source-directory: 'output'
+    destination-github-username: 'your-username'
+    destination-repository-name: 'your-repo'
+    user-email: your-email@example.com
+    target-branch: main
+  env:
+    SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+```
+
+## Documentation
+
+For complete usage documentation, examples, and troubleshooting, refer to the original documentation:
+https://cpina.github.io/push-to-another-repository-docs/
+
+## Compatibility
+
+This fork maintains full compatibility with the original action's API and parameters. It's a drop-in replacement that simply fixes the OpenSSL version mismatch issue.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a fork of [cpina/github-action-push-to-another-repository](https://githu
 OpenSSL version mismatch. Built against 3050003f, you have 30500010
 ```
 
-**Root Cause**: The Alpine Linux base image was using inconsistent OpenSSL versions between the container's SSH client and the system's OpenSSL library.
+**Root Cause**: The Alpine Linux base image was using inconsistent OpenSSL versions between the container's SSH client and the system's OpenSSL library. This is a known issue tracked in the Alpine Linux project: https://gitlab.alpinelinux.org/alpine/aports/-/issues/17547
 
 **Solution**: Updated the Dockerfile to:
 1. Pin Alpine to version 3.20 for consistency

--- a/README.md
+++ b/README.md
@@ -1,61 +1,19 @@
-# GitHub Action: Push to Another Repository (Fixed Fork)
+# github-action-push-to-another-repository
 
-## Why This Fork Exists
+> [!WARNING]
+> TL;DR: this repository is not maintained for any new development. I plan to
+> fix issues if they arise due to changes on GitHub, to minimise disruption of
+> existing usage.
+>
+> My circumstances changed since I started the GitHub Action in 2020. I am not
+> able to add functionality to it or fix issues.
+>
+> The action is 175 lines of shell script. Feel free to fork it and modify it
+> for your own use case.
+>
+> If you create a fork that might replace this one, I will add a note in the
+> documentation and the README.md. Please, open an issue and I will do it.
 
-This is a fork of [cpina/github-action-push-to-another-repository](https://github.com/cpina/github-action-push-to-another-repository) created to fix a critical OpenSSL version mismatch issue that was causing deployment failures.
+See the extensive documentation in https://cpina.github.io/push-to-another-repository-docs/ (includes examples, FAQ, troubleshooting, etc.).
 
-## What Was Changed
-
-### OpenSSL Version Mismatch Fix
-
-**Problem**: The original action was failing with the error:
-```
-OpenSSL version mismatch. Built against 3050003f, you have 30500010
-```
-
-**Root Cause**: The Alpine Linux base image was using inconsistent OpenSSL versions between the container's SSH client and the system's OpenSSL library. This is a known issue tracked in the Alpine Linux project: https://gitlab.alpinelinux.org/alpine/aports/-/issues/17547
-
-**Solution**: Updated the Dockerfile to:
-1. Pin Alpine to version 3.20 for consistency
-2. Explicitly install the `openssl` package alongside other dependencies
-3. Update package index before installation
-
-### Changes Made
-
-**Before**:
-```dockerfile
-FROM alpine:latest
-RUN apk add --no-cache git git-lfs openssh-client
-```
-
-**After**:
-```dockerfile
-FROM alpine:3.20
-RUN apk update && apk add --no-cache git git-lfs openssh-client openssl
-```
-
-## Usage
-
-Use this fork in your GitHub Actions workflows:
-
-```yaml
-- name: Push to another repository
-  uses: Play-Perfect/github-action-push-to-another-repository@main
-  with:
-    source-directory: 'output'
-    destination-github-username: 'your-username'
-    destination-repository-name: 'your-repo'
-    user-email: your-email@example.com
-    target-branch: main
-  env:
-    SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
-```
-
-## Documentation
-
-For complete usage documentation, examples, and troubleshooting, refer to the original documentation:
-https://cpina.github.io/push-to-another-repository-docs/
-
-## Compatibility
-
-This fork maintains full compatibility with the original action's API and parameters. It's a drop-in replacement that simply fixes the OpenSSL version mismatch issue.
+GitHub repository of the documentation: https://github.com/cpina/push-to-another-repository-docs


### PR DESCRIPTION
Fixes OpenSSL version mismatch error by pinning Alpine to 3.20 and explicitly installing openssl package.

**Problem**: Action fails with 'OpenSSL version mismatch. Built against 3050003f, you have 30500010'

**Solution**: 
- Pin Alpine base image to version 3.20 for consistency
- Add explicit openssl package installation
- Update package index before installation

**Related**: https://gitlab.alpinelinux.org/alpine/aports/-/issues/17547

This is a minimal fix that maintains full compatibility while resolving the OpenSSL version conflict.